### PR TITLE
Feature/upgrade carbon 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ircmaxell/password-compat": "~1.0",
         "filp/whoops": "^2.1",
         "monolog/monolog": "~1.6",
-        "nesbot/carbon": "~1.0",
+        "nesbot/carbon": "~2.0",
         "patchwork/utf8": "~1.1",
         "phpseclib/phpseclib": "~2.0",
         "predis/predis": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "^7.1"
     },
+    "conflict": {
+        "symfony/polyfill-php80": "*"
+    },
     "autoload": {
         "classmap": [
             "src/Illuminate/Queue/IlluminateQueueClosure.php"


### PR DESCRIPTION
Sebuah percobaan untuk upgrade Carbon ke v2.x. Ada satu hal yang membuat testnya gagal, yaitu konflik dari package `symfony/polyfill-php80` yang menjadi dependensi dari package symfony yang lain.

Ini terjadi karena PHP 8.0 mengenalkan fungsi baru `str_contains()` dan konflik dengan helper dari Laravel dengan nama fungsi yang sama.

Issue terkait: https://github.com/laravel/framework/issues/33045#issuecomment-660183170